### PR TITLE
Update packages and remove non-existing project references

### DIFF
--- a/src/HandlerLocator/HandlerLocator.csproj
+++ b/src/HandlerLocator/HandlerLocator.csproj
@@ -85,6 +85,11 @@
     </Reference>
     <Reference Include="System.Reflection.Metadata, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Reflection.Metadata.5.0.0\lib\net461\System.Reflection.Metadata.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reflection.Metadata, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.Metadata.5.0.0\lib\net461\System.Reflection.Metadata.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>

--- a/src/HandlerLocator/packages.config
+++ b/src/HandlerLocator/packages.config
@@ -1,24 +1,23 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Humanizer.Core" version="2.14.1" targetFramework="net48" />
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="6.0.0" targetFramework="net48" />
-  <package id="Microsoft.CodeAnalysis.Analyzers" version="3.3.3" targetFramework="net48" developmentDependency="true" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="7.0.0" targetFramework="net48" />
   <package id="Microsoft.CodeAnalysis.Common" version="4.4.0" targetFramework="net48" />
   <package id="Microsoft.CodeAnalysis.CSharp" version="4.4.0" targetFramework="net48" />
   <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="4.4.0" targetFramework="net48" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
-  <package id="System.Collections.Immutable" version="6.0.0" targetFramework="net48" />
-  <package id="System.Composition" version="6.0.0" targetFramework="net48" />
-  <package id="System.Composition.AttributedModel" version="6.0.0" targetFramework="net48" />
-  <package id="System.Composition.Convention" version="6.0.0" targetFramework="net48" />
-  <package id="System.Composition.Hosting" version="6.0.0" targetFramework="net48" />
-  <package id="System.Composition.Runtime" version="6.0.0" targetFramework="net48" />
-  <package id="System.Composition.TypedParts" version="6.0.0" targetFramework="net48" />
-  <package id="System.IO.Pipelines" version="6.0.3" targetFramework="net48" />
+  <package id="System.Collections.Immutable" version="7.0.0" targetFramework="net48" />
+  <package id="System.Composition" version="7.0.0" targetFramework="net48" />
+  <package id="System.Composition.AttributedModel" version="7.0.0" targetFramework="net48" />
+  <package id="System.Composition.Convention" version="7.0.0" targetFramework="net48" />
+  <package id="System.Composition.Hosting" version="7.0.0" targetFramework="net48" />
+  <package id="System.Composition.Runtime" version="7.0.0" targetFramework="net48" />
+  <package id="System.Composition.TypedParts" version="7.0.0" targetFramework="net48" />
+  <package id="System.IO.Pipelines" version="7.0.0" targetFramework="net48" />
   <package id="System.Memory" version="4.5.5" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
   <package id="System.Reflection.Metadata" version="5.0.0" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net48" />
-  <package id="System.Text.Encoding.CodePages" version="6.0.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="7.0.0-preview.2.22152.2" targetFramework="net48" />
+  <package id="System.Text.Encoding.CodePages" version="7.0.0" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
 </packages>

--- a/src/NavigateToHandler/NavigateToHandler.csproj
+++ b/src/NavigateToHandler/NavigateToHandler.csproj
@@ -90,12 +90,21 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp">
       <Version>4.4.0</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.ServiceHub.Framework">
+      <Version>4.0.2048</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices">
       <Version>4.4.0</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.RpcContracts">
+      <Version>17.4.9</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.4.2119">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="StreamJsonRpc">
+      <Version>2.13.33</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/NavigateToHandler/NavigateToHandler.csproj
+++ b/src/NavigateToHandler/NavigateToHandler.csproj
@@ -103,14 +103,10 @@
       <Project>{4D2562C6-9AAB-4250-B4B5-87DED302F309}</Project>
       <Name>HandlerLocator</Name>
     </ProjectReference>
-    <ProjectReference Include="..\NavigateToHandlerLocator\NavigateToHandlerLocator.csproj">
-      <Project>{f01597b8-070e-4f92-9ade-9415a28d8265}</Project>
-      <Name>NavigateToHandlerLocator</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>


### PR DESCRIPTION
# Description

This is a maintenance fix only. It removes a reference to a non-existing project as well as bump the version on a few packages that were causing warnings during build.

## Type of change

# How has this been tested?

- [x] Locally in Visual Studio (include version)
- [ ] Covered by test automation

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
