### PR TITLE
Add support for generic types and enums, and bump nuget packages

### DIFF
--- a/src/HandlerLocator/HandlerLocator.csproj
+++ b/src/HandlerLocator/HandlerLocator.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.3\build\Microsoft.CodeAnalysis.Analyzers.props" Condition="Exists('..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.3\build\Microsoft.CodeAnalysis.Analyzers.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -15,6 +15,7 @@
     <Deterministic>true</Deterministic>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -83,16 +84,12 @@
     <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Reflection.Metadata.5.0.0\lib\net461\System.Reflection.Metadata.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Reflection.Metadata.5.0.0\lib\net461\System.Reflection.Metadata.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Reflection.Metadata, Version=6.0.0.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.Metadata.6.0.1\lib\net461\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Text.Encoding.CodePages, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Text.Encoding.CodePages.6.0.0\lib\net461\System.Text.Encoding.CodePages.dll</HintPath>

--- a/src/HandlerLocator/IdentifiedHandler.cs
+++ b/src/HandlerLocator/IdentifiedHandler.cs
@@ -17,5 +17,6 @@ namespace HandlerLocator
         public string Fill { get; set; }
         public string DisplaySourceFile { get; set; }
         public int CaretPosition { get; set; }
+        public string AsArgument { get; set; }
     }
 }

--- a/src/HandlerLocator/packages.config
+++ b/src/HandlerLocator/packages.config
@@ -7,7 +7,7 @@
   <package id="Microsoft.CodeAnalysis.CSharp" version="4.4.0" targetFramework="net48" />
   <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="4.4.0" targetFramework="net48" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
-  <package id="System.Collections.Immutable" version="7.0.0" targetFramework="net48" />
+  <package id="System.Collections.Immutable" version="6.0.0" targetFramework="net48" />
   <package id="System.Composition" version="7.0.0" targetFramework="net48" />
   <package id="System.Composition.AttributedModel" version="7.0.0" targetFramework="net48" />
   <package id="System.Composition.Convention" version="7.0.0" targetFramework="net48" />
@@ -17,8 +17,8 @@
   <package id="System.IO.Pipelines" version="7.0.0" targetFramework="net48" />
   <package id="System.Memory" version="4.5.5" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
-  <package id="System.Reflection.Metadata" version="5.0.0" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="7.0.0-preview.2.22152.2" targetFramework="net48" />
+  <package id="System.Reflection.Metadata" version="6.0.1" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net48" />
   <package id="System.Text.Encoding.CodePages" version="7.0.0" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
 </packages>

--- a/src/NavigateToHandler/Commands/MyCommand.cs
+++ b/src/NavigateToHandler/Commands/MyCommand.cs
@@ -77,7 +77,7 @@ namespace NavigateToHandler
 
             foreach (IdentifiedHandler handler in allHandlers.OrderBy(h => h.SourceFile).ThenBy(h => h.TypeName).ThenBy(h => h.PublicMethod))
             {
-                await writer.WriteLineAsync($"{handler.DisplaySourceFile}:{handler.Fill}{handler.TypeName}.{handler.PublicMethod}()");
+                await writer.WriteLineAsync($"{handler.DisplaySourceFile}:{handler.Fill}{handler.TypeName}.{handler.PublicMethod}() as {handler.AsArgument}");
             }
 
             await writer.WriteLineAsync(underlines);

--- a/src/NavigateToHandler/NavigateToHandler.csproj
+++ b/src/NavigateToHandler/NavigateToHandler.csproj
@@ -4,6 +4,18 @@
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <UseWinFormsOutOfProcDesigner>True</UseWinFormsOutOfProcDesigner>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <UseWinFormsOutOfProcDesigner>True</UseWinFormsOutOfProcDesigner>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|arm64'">
+    <UseWinFormsOutOfProcDesigner>True</UseWinFormsOutOfProcDesigner>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|arm64'">
+    <UseWinFormsOutOfProcDesigner>True</UseWinFormsOutOfProcDesigner>
+  </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -35,6 +47,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <UseWinFormsOutOfProcDesigner>True</UseWinFormsOutOfProcDesigner>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -43,6 +56,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <UseWinFormsOutOfProcDesigner>True</UseWinFormsOutOfProcDesigner>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/NavigateToHandler/source.extension.vsixmanifest
+++ b/src/NavigateToHandler/source.extension.vsixmanifest
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="digitaldias.NavigateToHandler.001" Version="1.0" Language="en-US" Publisher="digitaldias" />
+        <Identity Id="digitaldias.NavigateToHandler.001" Version="1.2" Language="en-US" Publisher="digitaldias" />
         <DisplayName>Navigate to Handler</DisplayName>
         <Description xml:space="preserve">Adds a command that allows you to navigate to public or protected methods across the entire solution that consume the type under the cursor as a parameter. </Description>
         <MoreInfo>https://github.com/digitaldias/NavigateToHandler</MoreInfo>
+        <ReleaseNotes>Fixes a bug when documents such as razor would crash the extension. Also adds support for enums</ReleaseNotes>
         <Icon>Resources\Icon.png</Icon>
         <PreviewImage>Resources\Icon.png</PreviewImage>
-        <Preview>true</Preview>
     </Metadata>
     <Installation>
         <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0, 18.0)">


### PR DESCRIPTION
# Description

By request, this version adds the ability to navigate to generic types so the types such as the one below are now supported

```csharp
public class TestRequest<T> : IRequest{...}
```

Additionally, the extension now also lets you navigate to all public/protected methods that uses **enums**

Fixes 

An issue was found when using Roslyn, where unrecognized document types made the extension unresponsive. This issue has now been addressed.

## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)

# How has this been tested?

- [x] Locally in Visual Studio (include version)

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings