### PR TITLE
Introduce N2HMethodAccess Enum for Method Access and include perf chances and cleanup

### DIFF
--- a/src/HandlerLocator/HandlerLocator.csproj
+++ b/src/HandlerLocator/HandlerLocator.csproj
@@ -107,6 +107,7 @@
   <ItemGroup>
     <Compile Include="FindHandlerLocator.cs" />
     <Compile Include="IdentifiedHandler.cs" />
+    <Compile Include="N2HMethodAccess.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/HandlerLocator/IdentifiedHandler.cs
+++ b/src/HandlerLocator/IdentifiedHandler.cs
@@ -17,7 +17,7 @@ namespace HandlerLocator
 
         public string MethodName { get; set; }
 
-        public string MethodAccess { get; set; }
+        public N2HMethodAccess MethodAccess { get; set; }
 
         public int Column { get; set; }
 

--- a/src/HandlerLocator/N2HMethodAccess.cs
+++ b/src/HandlerLocator/N2HMethodAccess.cs
@@ -1,0 +1,12 @@
+﻿namespace HandlerLocator
+{
+    public enum N2HMethodAccess
+    {
+        Unknown = 0,
+        Public = 1,
+        Protected = 2,
+        Internal = 3,
+        Private = 4,
+        File = 5,
+    }
+}

--- a/src/NavigateToHandler/Commands/MyCommand.cs
+++ b/src/NavigateToHandler/Commands/MyCommand.cs
@@ -1,12 +1,12 @@
-﻿using HandlerLocator;
+﻿using System.Collections.Generic;
+using System.Linq;
+using HandlerLocator;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServices;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
 using NavigateToHandler.Dialogs;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace NavigateToHandler
 {
@@ -25,8 +25,8 @@ namespace NavigateToHandler
             var workspaceTask = VS.GetMefServiceAsync<VisualStudioWorkspace>();
             var documentViewTask = VS.Documents.GetActiveDocumentViewAsync();
 
-            var workspace = workspaceTask.Result;
-            var documentView = documentViewTask.Result;
+            var workspace = await workspaceTask;
+            var documentView = await documentViewTask;
             if (workspace is null || documentView is null)
                 return;
 
@@ -64,7 +64,8 @@ namespace NavigateToHandler
                 var handler = allHandlers.FirstOrDefault(handler =>
                 {
                     // If the handler is in the same file as the current document and contains the line search start position, skip it
-                    if (handler.SourceFile != documentView.FilePath) return true;
+                    if (handler.SourceFile != documentView.FilePath)
+                        return true;
 
                     return handler.LineNumber > lineNumber || handler.EndLineNumber < lineNumber;
                 });
@@ -92,7 +93,7 @@ namespace NavigateToHandler
 
             var firstOne = allHandlers.First();
 
-            await ShowHandlersInToolWindowAsync(allHandlers.ToList());
+            await ShowHandlersInToolWindowAsync([.. allHandlers]);
             string message = $"Found {allHandlers.Count()} public/protected methods that consume '{allHandlers.First().TypeToFind}':";
             string underlines = new('-', message.Length);
 

--- a/src/NavigateToHandler/Dialogs/DisplayResultsWindowControl.xaml.cs
+++ b/src/NavigateToHandler/Dialogs/DisplayResultsWindowControl.xaml.cs
@@ -22,7 +22,7 @@ public class IdentifiedHandlerViewModel
 
     public string MethodName => _handler.MethodName;
 
-    public string MethodAccess => _handler.MethodAccess;
+    public N2HMethodAccess MethodAccess => _handler.MethodAccess;
 
     public string LineNumber => _handler.LineNumber.ToString();
 


### PR DESCRIPTION
Refactor method access handling in FindHandlerLocator.cs by introducing the N2HMethodAccess enum, enhancing type safety and clarity. Update related files to use the new enum instead of strings for method access modifiers. Improve asynchronous handling in MyCommand.cs to prevent potential deadlocks and refactor code for better readability. Ensure project files are updated to recognize the new enum and maintain consistency across the codebase.

# Description

Please include a summary of the proposed change and, if applicable, which issue it fixes. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

- [ x] Locally in Visual Studio (include version)
- [ ] Covered by test automation

**Test Configuration**:
* Toolchain:
* SDK:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
